### PR TITLE
Update go.mod references.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/operator-framework/operator-lib v0.9.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.51.2
 	github.com/sirupsen/logrus v1.8.1
-	github.com/vmware-tanzu/velero v1.8.0 // TODO: Update this to a pinned version
+	github.com/vmware-tanzu/velero v1.9.2-rc.1 // TODO: Update this to a pinned version
 	k8s.io/api v0.23.0
 	k8s.io/apiextensions-apiserver v0.23.0
 	k8s.io/apimachinery v0.23.0
@@ -111,4 +111,5 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/vmware-tanzu/velero => github.com/konveyor/velero v0.10.2-0.20220915155627-5fc1e6615f62
+// replace with https://github.com/openshift/velero/tree/oadp-1.1
+replace github.com/vmware-tanzu/velero => github.com/openshift/velero v0.10.2-0.20220915155627-5fc1e6615f62

--- a/go.sum
+++ b/go.sum
@@ -482,8 +482,6 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konveyor/velero v0.10.2-0.20220915155627-5fc1e6615f62 h1:UY1A8za6/ZTuVfY3YplZLeqkNpDDtJgUU6he5sSP+Ow=
-github.com/konveyor/velero v0.10.2-0.20220915155627-5fc1e6615f62/go.mod h1:PJMXrsf21l4sof7DQrtCem4Ktjua0Xhi+hZzXUHsLsc=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -591,6 +589,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/openshift/api v0.0.0-20210805075156-d8fab4513288 h1:Yw96Z8gygCXxjeMTm55gGsTNxwnJkr6L2Baf3NsUQFU=
 github.com/openshift/api v0.0.0-20210805075156-d8fab4513288/go.mod h1:x81TFA31x1OMT9SYWukQqJ/KbmeveRN6fo+XeGRK8g0=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/velero v0.10.2-0.20220915155627-5fc1e6615f62 h1:10lAvBeuT07QJVodru4VqSedCD5lgCPb9/jAThkffdo=
+github.com/openshift/velero v0.10.2-0.20220915155627-5fc1e6615f62/go.mod h1:PJMXrsf21l4sof7DQrtCem4Ktjua0Xhi+hZzXUHsLsc=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/operator-framework/api v0.10.0/go.mod h1:tV0BUNvly7szq28ZPBXhjp1Sqg5yHCOeX19ui9K4vjI=
 github.com/operator-framework/api v0.10.7 h1:GlZJ6m+0WSVdSsSjTbhKKAvHXamWJXhwXHUhVwL8LBE=


### PR DESCRIPTION
`go get github.com/vmware-tanzu/velero@v1.9.2-rc.1`

`/s/konveyor/openshift/` for velero replace.